### PR TITLE
Add total procs cputime metric

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,28 @@ test-e2e: build pkg/collector/fixtures/sys/.unpacked pkg/collector/fixtures/proc
 	./scripts/e2e-test.sh -s stats-admin-query-all
 endif
 
+ifeq ($(CGO_BUILD), 0)
+.PHONY: test-e2e-update
+test-e2e-update: build pkg/collector/fixtures/sys/.unpacked pkg/collector/fixtures/proc/.unpacked
+	@echo ">> updating end-to-end tests outputs"
+	./scripts/e2e-test.sh -s exporter-cgroups-v1 -u || true
+	./scripts/e2e-test.sh -s exporter-cgroups-v2-nvidia -u || true
+	./scripts/e2e-test.sh -s exporter-cgroups-v2-amd -u || true
+	./scripts/e2e-test.sh -s exporter-cgroups-v2-nogpu -u || true
+	./scripts/e2e-test.sh -s exporter-cgroups-v2-procfs -u || true
+	./scripts/e2e-test.sh -s exporter-cgroups-v2-all-metrics -u || true
+else
+.PHONY: test-e2e-update
+test-e2e-update: build pkg/collector/fixtures/sys/.unpacked pkg/collector/fixtures/proc/.unpacked
+	@echo ">> updating end-to-end tests outputs"
+	./scripts/e2e-test.sh -s stats-account-query -u || true
+	./scripts/e2e-test.sh -s stats-jobuuid-query -u || true
+	./scripts/e2e-test.sh -s stats-jobid-query -u || true
+	./scripts/e2e-test.sh -s stats-jobuuid-jobid-query -u || true
+	./scripts/e2e-test.sh -s stats-admin-query -u || true
+	./scripts/e2e-test.sh -s stats-admin-query-all -u || true
+endif
+
 .PHONY: skip-test-e2e
 skip-test-e2e:
 	@echo ">> SKIP running end-to-end tests on $(GOHOSTOS)"

--- a/pkg/collector/fixtures/output/e2e-test-cgroupsv1-output.txt
+++ b/pkg/collector/fixtures/output/e2e-test-cgroupsv1-output.txt
@@ -19,23 +19,20 @@ batchjob_rapl_package_joules_total{hostname="",index="1",path="pkg/collector/fix
 # TYPE batchjob_scrape_collector_success gauge
 batchjob_scrape_collector_success{collector="ipmi_dcmi"} 1
 batchjob_scrape_collector_success{collector="rapl"} 1
-batchjob_scrape_collector_success{collector="slurm_job"} 1
-# HELP batchjob_slurm_job_cpu_system_seconds Cumulative CPU system seconds
+batchjob_scrape_collector_success{collector="slurm"} 1
+# HELP batchjob_slurm_job_cpu_system_seconds Total job CPU system seconds
 # TYPE batchjob_slurm_job_cpu_system_seconds gauge
 batchjob_slurm_job_cpu_system_seconds{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 0.45
-# HELP batchjob_slurm_job_cpu_total_seconds Cumulative CPU total seconds
-# TYPE batchjob_slurm_job_cpu_total_seconds gauge
-batchjob_slurm_job_cpu_total_seconds{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 1.012410966
-# HELP batchjob_slurm_job_cpu_user_seconds Cumulative CPU user seconds
+# HELP batchjob_slurm_job_cpu_user_seconds Total job CPU user seconds
 # TYPE batchjob_slurm_job_cpu_user_seconds gauge
 batchjob_slurm_job_cpu_user_seconds{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 0.39
-# HELP batchjob_slurm_job_cpus Number of CPUs
+# HELP batchjob_slurm_job_cpus Total number of job CPUs
 # TYPE batchjob_slurm_job_cpus gauge
 batchjob_slurm_job_cpus{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 0
-# HELP batchjob_slurm_job_gpu_jobid_flag Indicates running job on GPU, 1=job running
-# TYPE batchjob_slurm_job_gpu_jobid_flag gauge
-batchjob_slurm_job_gpu_jobid_flag{UUID="GPU-61a65011-6571-a64n-5ab8-66cbb6f7f9c3",batch="slurm",hostname="",index="3",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",uuid="GPU-61a65011-6571-a64n-5ab8-66cbb6f7f9c3"} 1
-batchjob_slurm_job_gpu_jobid_flag{UUID="GPU-61a65011-6571-a6d2-5th8-66cbb6f7f9c3",batch="slurm",hostname="",index="2",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",uuid="GPU-61a65011-6571-a6d2-5th8-66cbb6f7f9c3"} 1
+# HELP batchjob_slurm_job_gpu_index_flag Indicates running job on GPU, 1=job running
+# TYPE batchjob_slurm_job_gpu_index_flag gauge
+batchjob_slurm_job_gpu_index_flag{UUID="GPU-61a65011-6571-a64n-5ab8-66cbb6f7f9c3",batch="slurm",hostname="",index="3",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",uuid="GPU-61a65011-6571-a64n-5ab8-66cbb6f7f9c3"} 1
+batchjob_slurm_job_gpu_index_flag{UUID="GPU-61a65011-6571-a6d2-5th8-66cbb6f7f9c3",batch="slurm",hostname="",index="2",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",uuid="GPU-61a65011-6571-a6d2-5th8-66cbb6f7f9c3"} 1
 # HELP batchjob_slurm_job_memory_cache_bytes Memory cache used in bytes
 # TYPE batchjob_slurm_job_memory_cache_bytes gauge
 batchjob_slurm_job_memory_cache_bytes{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 2.1086208e+07
@@ -51,9 +48,12 @@ batchjob_slurm_job_memory_total_bytes{batch="slurm",hostname="",jobaccount="test
 # HELP batchjob_slurm_job_memory_used_bytes Memory used in bytes
 # TYPE batchjob_slurm_job_memory_used_bytes gauge
 batchjob_slurm_job_memory_used_bytes{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 4.0194048e+07
-# HELP batchjob_slurm_job_system_memory_total_bytes Available total system memory in bytes
-# TYPE batchjob_slurm_job_system_memory_total_bytes gauge
-batchjob_slurm_job_system_memory_total_bytes{batch="slurm",hostname=""} 1.6042172416e+10
+# HELP batchjob_system_memory_total_bytes Available total system memory in bytes
+# TYPE batchjob_system_memory_total_bytes gauge
+batchjob_system_memory_total_bytes{batch="slurm",hostname=""} 1.6042172416e+10
+# HELP batchjob_system_proc_cpu_total_seconds Total processes CPU time in seconds
+# TYPE batchjob_system_proc_cpu_total_seconds gauge
+batchjob_system_proc_cpu_total_seconds{batch="slurm",hostname=""} 4137.76
 # HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
 # TYPE go_gc_duration_seconds summary
 # HELP go_goroutines Number of goroutines that currently exist.

--- a/pkg/collector/fixtures/output/e2e-test-cgroupsv2-all-metrics-output.txt
+++ b/pkg/collector/fixtures/output/e2e-test-cgroupsv2-all-metrics-output.txt
@@ -19,33 +19,30 @@ batchjob_rapl_package_joules_total{hostname="",index="1",path="pkg/collector/fix
 # TYPE batchjob_scrape_collector_success gauge
 batchjob_scrape_collector_success{collector="ipmi_dcmi"} 1
 batchjob_scrape_collector_success{collector="rapl"} 1
-batchjob_scrape_collector_success{collector="slurm_job"} 1
-# HELP batchjob_slurm_job_cpu_psi_seconds Cumulative CPU PSI in seconds
+batchjob_scrape_collector_success{collector="slurm"} 1
+# HELP batchjob_slurm_job_cpu_psi_seconds Total CPU PSI in seconds
 # TYPE batchjob_slurm_job_cpu_psi_seconds gauge
 batchjob_slurm_job_cpu_psi_seconds{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 0
-# HELP batchjob_slurm_job_cpu_system_seconds Cumulative CPU system seconds
+# HELP batchjob_slurm_job_cpu_system_seconds Total job CPU system seconds
 # TYPE batchjob_slurm_job_cpu_system_seconds gauge
 batchjob_slurm_job_cpu_system_seconds{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 115.777502
-# HELP batchjob_slurm_job_cpu_total_seconds Cumulative CPU total seconds
-# TYPE batchjob_slurm_job_cpu_total_seconds gauge
-batchjob_slurm_job_cpu_total_seconds{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 60491.070351
-# HELP batchjob_slurm_job_cpu_user_seconds Cumulative CPU user seconds
+# HELP batchjob_slurm_job_cpu_user_seconds Total job CPU user seconds
 # TYPE batchjob_slurm_job_cpu_user_seconds gauge
 batchjob_slurm_job_cpu_user_seconds{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 60375.292848
-# HELP batchjob_slurm_job_cpus Number of CPUs
+# HELP batchjob_slurm_job_cpus Total number of job CPUs
 # TYPE batchjob_slurm_job_cpus gauge
 batchjob_slurm_job_cpus{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 2
-# HELP batchjob_slurm_job_gpu_jobid_flag Indicates running job on GPU, 1=job running
-# TYPE batchjob_slurm_job_gpu_jobid_flag gauge
-batchjob_slurm_job_gpu_jobid_flag{UUID="20170005280c",batch="slurm",hostname="",index="3",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",uuid="20170005280c"} 1
-batchjob_slurm_job_gpu_jobid_flag{UUID="20180003050c",batch="slurm",hostname="",index="2",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",uuid="20180003050c"} 1
+# HELP batchjob_slurm_job_gpu_index_flag Indicates running job on GPU, 1=job running
+# TYPE batchjob_slurm_job_gpu_index_flag gauge
+batchjob_slurm_job_gpu_index_flag{UUID="20170005280c",batch="slurm",hostname="",index="3",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",uuid="20170005280c"} 1
+batchjob_slurm_job_gpu_index_flag{UUID="20180003050c",batch="slurm",hostname="",index="2",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",uuid="20180003050c"} 1
 # HELP batchjob_slurm_job_memory_cache_bytes Memory cache used in bytes
 # TYPE batchjob_slurm_job_memory_cache_bytes gauge
 batchjob_slurm_job_memory_cache_bytes{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 0
 # HELP batchjob_slurm_job_memory_fail_count Memory fail count
 # TYPE batchjob_slurm_job_memory_fail_count gauge
 batchjob_slurm_job_memory_fail_count{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 0
-# HELP batchjob_slurm_job_memory_psi_seconds Cumulative memory PSI in seconds
+# HELP batchjob_slurm_job_memory_psi_seconds Total memory PSI in seconds
 # TYPE batchjob_slurm_job_memory_psi_seconds gauge
 batchjob_slurm_job_memory_psi_seconds{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 0
 # HELP batchjob_slurm_job_memory_rss_bytes Memory RSS used in bytes
@@ -66,9 +63,12 @@ batchjob_slurm_job_memsw_total_bytes{batch="slurm",hostname="",jobaccount="testa
 # HELP batchjob_slurm_job_memsw_used_bytes Swap used in bytes
 # TYPE batchjob_slurm_job_memsw_used_bytes gauge
 batchjob_slurm_job_memsw_used_bytes{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 0
-# HELP batchjob_slurm_job_system_memory_total_bytes Available total system memory in bytes
-# TYPE batchjob_slurm_job_system_memory_total_bytes gauge
-batchjob_slurm_job_system_memory_total_bytes{batch="slurm",hostname=""} 1.6042172416e+10
+# HELP batchjob_system_memory_total_bytes Available total system memory in bytes
+# TYPE batchjob_system_memory_total_bytes gauge
+batchjob_system_memory_total_bytes{batch="slurm",hostname=""} 1.6042172416e+10
+# HELP batchjob_system_proc_cpu_total_seconds Total processes CPU time in seconds
+# TYPE batchjob_system_proc_cpu_total_seconds gauge
+batchjob_system_proc_cpu_total_seconds{batch="slurm",hostname=""} 4137.76
 # HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
 # TYPE go_gc_duration_seconds summary
 # HELP go_goroutines Number of goroutines that currently exist.

--- a/pkg/collector/fixtures/output/e2e-test-cgroupsv2-amd-output.txt
+++ b/pkg/collector/fixtures/output/e2e-test-cgroupsv2-amd-output.txt
@@ -19,23 +19,20 @@ batchjob_rapl_package_joules_total{hostname="",index="1",path="pkg/collector/fix
 # TYPE batchjob_scrape_collector_success gauge
 batchjob_scrape_collector_success{collector="ipmi_dcmi"} 1
 batchjob_scrape_collector_success{collector="rapl"} 1
-batchjob_scrape_collector_success{collector="slurm_job"} 1
-# HELP batchjob_slurm_job_cpu_system_seconds Cumulative CPU system seconds
+batchjob_scrape_collector_success{collector="slurm"} 1
+# HELP batchjob_slurm_job_cpu_system_seconds Total job CPU system seconds
 # TYPE batchjob_slurm_job_cpu_system_seconds gauge
 batchjob_slurm_job_cpu_system_seconds{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 115.777502
-# HELP batchjob_slurm_job_cpu_total_seconds Cumulative CPU total seconds
-# TYPE batchjob_slurm_job_cpu_total_seconds gauge
-batchjob_slurm_job_cpu_total_seconds{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 60491.070351
-# HELP batchjob_slurm_job_cpu_user_seconds Cumulative CPU user seconds
+# HELP batchjob_slurm_job_cpu_user_seconds Total job CPU user seconds
 # TYPE batchjob_slurm_job_cpu_user_seconds gauge
 batchjob_slurm_job_cpu_user_seconds{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 60375.292848
-# HELP batchjob_slurm_job_cpus Number of CPUs
+# HELP batchjob_slurm_job_cpus Total number of job CPUs
 # TYPE batchjob_slurm_job_cpus gauge
 batchjob_slurm_job_cpus{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 2
-# HELP batchjob_slurm_job_gpu_jobid_flag Indicates running job on GPU, 1=job running
-# TYPE batchjob_slurm_job_gpu_jobid_flag gauge
-batchjob_slurm_job_gpu_jobid_flag{UUID="20170005280c",batch="slurm",hostname="",index="3",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",uuid="20170005280c"} 1
-batchjob_slurm_job_gpu_jobid_flag{UUID="20180003050c",batch="slurm",hostname="",index="2",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",uuid="20180003050c"} 1
+# HELP batchjob_slurm_job_gpu_index_flag Indicates running job on GPU, 1=job running
+# TYPE batchjob_slurm_job_gpu_index_flag gauge
+batchjob_slurm_job_gpu_index_flag{UUID="20170005280c",batch="slurm",hostname="",index="3",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",uuid="20170005280c"} 1
+batchjob_slurm_job_gpu_index_flag{UUID="20180003050c",batch="slurm",hostname="",index="2",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",uuid="20180003050c"} 1
 # HELP batchjob_slurm_job_memory_cache_bytes Memory cache used in bytes
 # TYPE batchjob_slurm_job_memory_cache_bytes gauge
 batchjob_slurm_job_memory_cache_bytes{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 0
@@ -51,9 +48,12 @@ batchjob_slurm_job_memory_total_bytes{batch="slurm",hostname="",jobaccount="test
 # HELP batchjob_slurm_job_memory_used_bytes Memory used in bytes
 # TYPE batchjob_slurm_job_memory_used_bytes gauge
 batchjob_slurm_job_memory_used_bytes{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 4.111491072e+09
-# HELP batchjob_slurm_job_system_memory_total_bytes Available total system memory in bytes
-# TYPE batchjob_slurm_job_system_memory_total_bytes gauge
-batchjob_slurm_job_system_memory_total_bytes{batch="slurm",hostname=""} 1.6042172416e+10
+# HELP batchjob_system_memory_total_bytes Available total system memory in bytes
+# TYPE batchjob_system_memory_total_bytes gauge
+batchjob_system_memory_total_bytes{batch="slurm",hostname=""} 1.6042172416e+10
+# HELP batchjob_system_proc_cpu_total_seconds Total processes CPU time in seconds
+# TYPE batchjob_system_proc_cpu_total_seconds gauge
+batchjob_system_proc_cpu_total_seconds{batch="slurm",hostname=""} 4137.76
 # HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
 # TYPE go_gc_duration_seconds summary
 # HELP go_goroutines Number of goroutines that currently exist.

--- a/pkg/collector/fixtures/output/e2e-test-cgroupsv2-nogpu-output.txt
+++ b/pkg/collector/fixtures/output/e2e-test-cgroupsv2-nogpu-output.txt
@@ -19,17 +19,14 @@ batchjob_rapl_package_joules_total{hostname="",index="1",path="pkg/collector/fix
 # TYPE batchjob_scrape_collector_success gauge
 batchjob_scrape_collector_success{collector="ipmi_dcmi"} 1
 batchjob_scrape_collector_success{collector="rapl"} 1
-batchjob_scrape_collector_success{collector="slurm_job"} 1
-# HELP batchjob_slurm_job_cpu_system_seconds Cumulative CPU system seconds
+batchjob_scrape_collector_success{collector="slurm"} 1
+# HELP batchjob_slurm_job_cpu_system_seconds Total job CPU system seconds
 # TYPE batchjob_slurm_job_cpu_system_seconds gauge
 batchjob_slurm_job_cpu_system_seconds{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 115.777502
-# HELP batchjob_slurm_job_cpu_total_seconds Cumulative CPU total seconds
-# TYPE batchjob_slurm_job_cpu_total_seconds gauge
-batchjob_slurm_job_cpu_total_seconds{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 60491.070351
-# HELP batchjob_slurm_job_cpu_user_seconds Cumulative CPU user seconds
+# HELP batchjob_slurm_job_cpu_user_seconds Total job CPU user seconds
 # TYPE batchjob_slurm_job_cpu_user_seconds gauge
 batchjob_slurm_job_cpu_user_seconds{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 60375.292848
-# HELP batchjob_slurm_job_cpus Number of CPUs
+# HELP batchjob_slurm_job_cpus Total number of job CPUs
 # TYPE batchjob_slurm_job_cpus gauge
 batchjob_slurm_job_cpus{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 2
 # HELP batchjob_slurm_job_memory_cache_bytes Memory cache used in bytes
@@ -47,9 +44,12 @@ batchjob_slurm_job_memory_total_bytes{batch="slurm",hostname="",jobaccount="test
 # HELP batchjob_slurm_job_memory_used_bytes Memory used in bytes
 # TYPE batchjob_slurm_job_memory_used_bytes gauge
 batchjob_slurm_job_memory_used_bytes{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 4.111491072e+09
-# HELP batchjob_slurm_job_system_memory_total_bytes Available total system memory in bytes
-# TYPE batchjob_slurm_job_system_memory_total_bytes gauge
-batchjob_slurm_job_system_memory_total_bytes{batch="slurm",hostname=""} 1.6042172416e+10
+# HELP batchjob_system_memory_total_bytes Available total system memory in bytes
+# TYPE batchjob_system_memory_total_bytes gauge
+batchjob_system_memory_total_bytes{batch="slurm",hostname=""} 1.6042172416e+10
+# HELP batchjob_system_proc_cpu_total_seconds Total processes CPU time in seconds
+# TYPE batchjob_system_proc_cpu_total_seconds gauge
+batchjob_system_proc_cpu_total_seconds{batch="slurm",hostname=""} 4137.76
 # HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
 # TYPE go_gc_duration_seconds summary
 # HELP go_goroutines Number of goroutines that currently exist.

--- a/pkg/collector/fixtures/output/e2e-test-cgroupsv2-nvidia-output.txt
+++ b/pkg/collector/fixtures/output/e2e-test-cgroupsv2-nvidia-output.txt
@@ -19,23 +19,20 @@ batchjob_rapl_package_joules_total{hostname="",index="1",path="pkg/collector/fix
 # TYPE batchjob_scrape_collector_success gauge
 batchjob_scrape_collector_success{collector="ipmi_dcmi"} 1
 batchjob_scrape_collector_success{collector="rapl"} 1
-batchjob_scrape_collector_success{collector="slurm_job"} 1
-# HELP batchjob_slurm_job_cpu_system_seconds Cumulative CPU system seconds
+batchjob_scrape_collector_success{collector="slurm"} 1
+# HELP batchjob_slurm_job_cpu_system_seconds Total job CPU system seconds
 # TYPE batchjob_slurm_job_cpu_system_seconds gauge
 batchjob_slurm_job_cpu_system_seconds{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 115.777502
-# HELP batchjob_slurm_job_cpu_total_seconds Cumulative CPU total seconds
-# TYPE batchjob_slurm_job_cpu_total_seconds gauge
-batchjob_slurm_job_cpu_total_seconds{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 60491.070351
-# HELP batchjob_slurm_job_cpu_user_seconds Cumulative CPU user seconds
+# HELP batchjob_slurm_job_cpu_user_seconds Total job CPU user seconds
 # TYPE batchjob_slurm_job_cpu_user_seconds gauge
 batchjob_slurm_job_cpu_user_seconds{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 60375.292848
-# HELP batchjob_slurm_job_cpus Number of CPUs
+# HELP batchjob_slurm_job_cpus Total number of job CPUs
 # TYPE batchjob_slurm_job_cpus gauge
 batchjob_slurm_job_cpus{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 2
-# HELP batchjob_slurm_job_gpu_jobid_flag Indicates running job on GPU, 1=job running
-# TYPE batchjob_slurm_job_gpu_jobid_flag gauge
-batchjob_slurm_job_gpu_jobid_flag{UUID="GPU-61a65011-6571-a64n-5ab8-66cbb6f7f9c3",batch="slurm",hostname="",index="3",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",uuid="GPU-61a65011-6571-a64n-5ab8-66cbb6f7f9c3"} 1
-batchjob_slurm_job_gpu_jobid_flag{UUID="GPU-61a65011-6571-a6d2-5th8-66cbb6f7f9c3",batch="slurm",hostname="",index="2",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",uuid="GPU-61a65011-6571-a6d2-5th8-66cbb6f7f9c3"} 1
+# HELP batchjob_slurm_job_gpu_index_flag Indicates running job on GPU, 1=job running
+# TYPE batchjob_slurm_job_gpu_index_flag gauge
+batchjob_slurm_job_gpu_index_flag{UUID="GPU-61a65011-6571-a64n-5ab8-66cbb6f7f9c3",batch="slurm",hostname="",index="3",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",uuid="GPU-61a65011-6571-a64n-5ab8-66cbb6f7f9c3"} 1
+batchjob_slurm_job_gpu_index_flag{UUID="GPU-61a65011-6571-a6d2-5th8-66cbb6f7f9c3",batch="slurm",hostname="",index="2",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",uuid="GPU-61a65011-6571-a6d2-5th8-66cbb6f7f9c3"} 1
 # HELP batchjob_slurm_job_memory_cache_bytes Memory cache used in bytes
 # TYPE batchjob_slurm_job_memory_cache_bytes gauge
 batchjob_slurm_job_memory_cache_bytes{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 0
@@ -51,9 +48,12 @@ batchjob_slurm_job_memory_total_bytes{batch="slurm",hostname="",jobaccount="test
 # HELP batchjob_slurm_job_memory_used_bytes Memory used in bytes
 # TYPE batchjob_slurm_job_memory_used_bytes gauge
 batchjob_slurm_job_memory_used_bytes{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 4.111491072e+09
-# HELP batchjob_slurm_job_system_memory_total_bytes Available total system memory in bytes
-# TYPE batchjob_slurm_job_system_memory_total_bytes gauge
-batchjob_slurm_job_system_memory_total_bytes{batch="slurm",hostname=""} 1.6042172416e+10
+# HELP batchjob_system_memory_total_bytes Available total system memory in bytes
+# TYPE batchjob_system_memory_total_bytes gauge
+batchjob_system_memory_total_bytes{batch="slurm",hostname=""} 1.6042172416e+10
+# HELP batchjob_system_proc_cpu_total_seconds Total processes CPU time in seconds
+# TYPE batchjob_system_proc_cpu_total_seconds gauge
+batchjob_system_proc_cpu_total_seconds{batch="slurm",hostname=""} 4137.76
 # HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
 # TYPE go_gc_duration_seconds summary
 # HELP go_goroutines Number of goroutines that currently exist.

--- a/pkg/collector/fixtures/output/e2e-test-cgroupsv2-procfs-output.txt
+++ b/pkg/collector/fixtures/output/e2e-test-cgroupsv2-procfs-output.txt
@@ -19,23 +19,20 @@ batchjob_rapl_package_joules_total{hostname="",index="1",path="pkg/collector/fix
 # TYPE batchjob_scrape_collector_success gauge
 batchjob_scrape_collector_success{collector="ipmi_dcmi"} 1
 batchjob_scrape_collector_success{collector="rapl"} 1
-batchjob_scrape_collector_success{collector="slurm_job"} 1
-# HELP batchjob_slurm_job_cpu_system_seconds Cumulative CPU system seconds
+batchjob_scrape_collector_success{collector="slurm"} 1
+# HELP batchjob_slurm_job_cpu_system_seconds Total job CPU system seconds
 # TYPE batchjob_slurm_job_cpu_system_seconds gauge
 batchjob_slurm_job_cpu_system_seconds{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 115.777502
-# HELP batchjob_slurm_job_cpu_total_seconds Cumulative CPU total seconds
-# TYPE batchjob_slurm_job_cpu_total_seconds gauge
-batchjob_slurm_job_cpu_total_seconds{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 60491.070351
-# HELP batchjob_slurm_job_cpu_user_seconds Cumulative CPU user seconds
+# HELP batchjob_slurm_job_cpu_user_seconds Total job CPU user seconds
 # TYPE batchjob_slurm_job_cpu_user_seconds gauge
 batchjob_slurm_job_cpu_user_seconds{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 60375.292848
-# HELP batchjob_slurm_job_cpus Number of CPUs
+# HELP batchjob_slurm_job_cpus Total number of job CPUs
 # TYPE batchjob_slurm_job_cpus gauge
 batchjob_slurm_job_cpus{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 2
-# HELP batchjob_slurm_job_gpu_jobid_flag Indicates running job on GPU, 1=job running
-# TYPE batchjob_slurm_job_gpu_jobid_flag gauge
-batchjob_slurm_job_gpu_jobid_flag{UUID="GPU-61a65011-6571-a64n-5ab8-66cbb6f7f9c3",batch="slurm",hostname="",index="3",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",uuid="GPU-61a65011-6571-a64n-5ab8-66cbb6f7f9c3"} 1
-batchjob_slurm_job_gpu_jobid_flag{UUID="GPU-61a65011-6571-a6d2-5th8-66cbb6f7f9c3",batch="slurm",hostname="",index="2",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",uuid="GPU-61a65011-6571-a6d2-5th8-66cbb6f7f9c3"} 1
+# HELP batchjob_slurm_job_gpu_index_flag Indicates running job on GPU, 1=job running
+# TYPE batchjob_slurm_job_gpu_index_flag gauge
+batchjob_slurm_job_gpu_index_flag{UUID="GPU-61a65011-6571-a64n-5ab8-66cbb6f7f9c3",batch="slurm",hostname="",index="3",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",uuid="GPU-61a65011-6571-a64n-5ab8-66cbb6f7f9c3"} 1
+batchjob_slurm_job_gpu_index_flag{UUID="GPU-61a65011-6571-a6d2-5th8-66cbb6f7f9c3",batch="slurm",hostname="",index="2",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",uuid="GPU-61a65011-6571-a6d2-5th8-66cbb6f7f9c3"} 1
 # HELP batchjob_slurm_job_memory_cache_bytes Memory cache used in bytes
 # TYPE batchjob_slurm_job_memory_cache_bytes gauge
 batchjob_slurm_job_memory_cache_bytes{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 0
@@ -51,9 +48,12 @@ batchjob_slurm_job_memory_total_bytes{batch="slurm",hostname="",jobaccount="test
 # HELP batchjob_slurm_job_memory_used_bytes Memory used in bytes
 # TYPE batchjob_slurm_job_memory_used_bytes gauge
 batchjob_slurm_job_memory_used_bytes{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 4.111491072e+09
-# HELP batchjob_slurm_job_system_memory_total_bytes Available total system memory in bytes
-# TYPE batchjob_slurm_job_system_memory_total_bytes gauge
-batchjob_slurm_job_system_memory_total_bytes{batch="slurm",hostname=""} 1.6042172416e+10
+# HELP batchjob_system_memory_total_bytes Available total system memory in bytes
+# TYPE batchjob_system_memory_total_bytes gauge
+batchjob_system_memory_total_bytes{batch="slurm",hostname=""} 1.6042172416e+10
+# HELP batchjob_system_proc_cpu_total_seconds Total processes CPU time in seconds
+# TYPE batchjob_system_proc_cpu_total_seconds gauge
+batchjob_system_proc_cpu_total_seconds{batch="slurm",hostname=""} 4137.76
 # HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
 # TYPE go_gc_duration_seconds summary
 # HELP go_goroutines Number of goroutines that currently exist.

--- a/pkg/collector/slurm.go
+++ b/pkg/collector/slurm.go
@@ -117,22 +117,22 @@ type slurmCollector struct {
 	cpuUser          *prometheus.Desc
 	cpuSystem        *prometheus.Desc
 	// cpuTotal         *prometheus.Desc
-	cpus             *prometheus.Desc
-	cpuPressure      *prometheus.Desc
-	memoryRSS        *prometheus.Desc
-	memoryCache      *prometheus.Desc
-	memoryUsed       *prometheus.Desc
-	memoryTotal      *prometheus.Desc
-	memoryFailCount  *prometheus.Desc
-	memswUsed        *prometheus.Desc
-	memswTotal       *prometheus.Desc
-	memswFailCount   *prometheus.Desc
-	memoryPressure   *prometheus.Desc
-	memoryAvailable  *prometheus.Desc
-	procCpuTotal     *prometheus.Desc
-	gpuJobFlag       *prometheus.Desc
-	collectError     *prometheus.Desc
-	logger           log.Logger
+	cpus            *prometheus.Desc
+	cpuPressure     *prometheus.Desc
+	memoryRSS       *prometheus.Desc
+	memoryCache     *prometheus.Desc
+	memoryUsed      *prometheus.Desc
+	memoryTotal     *prometheus.Desc
+	memoryFailCount *prometheus.Desc
+	memswUsed       *prometheus.Desc
+	memswTotal      *prometheus.Desc
+	memswFailCount  *prometheus.Desc
+	memoryPressure  *prometheus.Desc
+	memoryAvailable *prometheus.Desc
+	procCpuTotal    *prometheus.Desc
+	gpuJobFlag      *prometheus.Desc
+	collectError    *prometheus.Desc
+	logger          log.Logger
 }
 
 func init() {
@@ -302,7 +302,7 @@ func NewSlurmCollector(logger log.Logger) (Collector, error) {
 			nil,
 		),
 		gpuJobFlag: prometheus.NewDesc(
-			prometheus.BuildFQName(Namespace, slurmCollectorSubsystem, "gpu_jobid_flag"),
+			prometheus.BuildFQName(Namespace, slurmCollectorSubsystem, "job_gpu_index_flag"),
 			"Indicates running job on GPU, 1=job running",
 			[]string{"batch", "hostname", "jobid", "jobuser", "jobaccount", "jobuuid", "index", "uuid", "UUID"}, nil,
 		),


### PR DESCRIPTION
- Total CPU time from `/proc/stat` is exported
- Metric names are tidied
- Update test outputs