### PR TITLE
Split node metrics into separate collectors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: tests
+name: build
 on:
   push:
     branches:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: tests
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "go.sum"
+      - "go.mod"
+      - "**.go"
+      - ".github/workflows/build.yml"
+  pull_request:
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.21.x
+
+      - name: Install promu
+        run: |
+          make promu
+          go mod download
+
+      - name: Cross compile Go packages
+        run: promu --config .promu-go.yml crossbuild -v
+
+      - name: Cross compile CGo packages
+        run: |
+          sed -i -e 's/CGO_BUILD               ?= 0/CGO_BUILD               ?= 1/g' Makefile
+          promu --config .promu-cgo.yml crossbuild -v
+      
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-artifacts
+          path: .build/linux-amd64
+          retention-days: 3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,7 @@ on:
       - "go.sum"
       - "go.mod"
       - "**.go"
-      - "scripts/errcheck_excludes.txt"
-      - ".github/workflows/golangci-lint.yml"
-      - ".golangci.yml"
+      - ".github/workflows/test.yml"
   pull_request:
 
 jobs:
@@ -33,35 +31,3 @@ jobs:
 
       - name: Run test for CGo packages
         run: CGO_BUILD=1 make
-  
-  build:
-    name: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-            go-version: 1.21.x
-
-      - name: Install promu
-        run: |
-          make promu
-          go mod download
-
-      - name: Cross compile Go packages
-        run: promu --config .promu-go.yml crossbuild -v
-
-      - name: Cross compile CGo packages
-        run: |
-          sed -i -e 's/CGO_BUILD               ?= 0/CGO_BUILD               ?= 1/g' Makefile
-          promu --config .promu-cgo.yml crossbuild -v
-      
-      - name: Upload UI Test artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: ui-test-output
-          path: .build
-          retention-days: 3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: tests
 on:
   push:
+    branches:
+      - "main"
     paths:
       - "go.sum"
       - "go.mod"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,67 @@
+name: tests
+on:
+  push:
+    paths:
+      - "go.sum"
+      - "go.mod"
+      - "**.go"
+      - "scripts/errcheck_excludes.txt"
+      - ".github/workflows/golangci-lint.yml"
+      - ".golangci.yml"
+  pull_request:
+
+jobs:
+  tests:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.21.x
+
+      - name: Install promu
+        run: |
+          make promu
+          go mod download
+
+      - name: Run test for pure Go packages
+        run: make
+
+      - name: Run test for CGo packages
+        run: CGO_BUILD=1 make
+  
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+            go-version: 1.21.x
+
+      - name: Install promu
+        run: |
+          make promu
+          go mod download
+
+      - name: Cross compile Go packages
+        run: promu --config .promu-go.yml crossbuild -v
+
+      - name: Cross compile CGo packages
+        run: |
+          sed -i -e 's/CGO_BUILD               ?= 0/CGO_BUILD               ?= 1/g' Makefile
+          promu --config .promu-cgo.yml crossbuild -v
+      
+      - name: Upload UI Test artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ui-test-output
+          path: .build
+          retention-days: 3

--- a/pkg/collector/cpu.go
+++ b/pkg/collector/cpu.go
@@ -1,0 +1,157 @@
+//go:build !nocpu
+// +build !nocpu
+
+package collector
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/procfs"
+)
+
+type cpuCollector struct {
+	fs            procfs.FS
+	cpu           *prometheus.Desc
+	logger        log.Logger
+	cpuStats      procfs.CPUStat
+	cpuStatsMutex sync.Mutex
+	hostname      string
+}
+
+// Idle jump back limit in seconds.
+const jumpBackSeconds = 3.0
+
+const cpuCollectorSubsystem = "cpu"
+
+var (
+	jumpBackDebugMessage = fmt.Sprintf("CPU Idle counter jumped backwards more than %f seconds, possible hotplug event, resetting CPU stats", jumpBackSeconds)
+)
+
+func init() {
+	RegisterCollector(cpuCollectorSubsystem, defaultEnabled, NewCPUCollector)
+}
+
+// NewCPUCollector returns a new Collector exposing kernel/system statistics.
+func NewCPUCollector(logger log.Logger) (Collector, error) {
+	fs, err := procfs.NewFS(*procfsPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open procfs: %w", err)
+	}
+
+	return &cpuCollector{
+		fs: fs,
+		cpu: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, cpuCollectorSubsystem, "seconds_total"),
+			"Seconds the CPUs spent in each mode.",
+			[]string{"hostname", "mode"}, nil,
+		),
+		logger:   logger,
+		hostname: hostname,
+		cpuStats: procfs.CPUStat{},
+	}, nil
+}
+
+// Update reads /proc/stat through procfs and exports CPU-related metrics.
+func (c *cpuCollector) Update(ch chan<- prometheus.Metric) error {
+	stats, err := c.fs.Stat()
+	if err != nil {
+		return err
+	}
+
+	c.updateCPUStats(stats.CPUTotal)
+
+	// Acquire a lock to read the stats.
+	c.cpuStatsMutex.Lock()
+	defer c.cpuStatsMutex.Unlock()
+	ch <- prometheus.MustNewConstMetric(c.cpu, prometheus.CounterValue, c.cpuStats.User, c.hostname, "user")
+	ch <- prometheus.MustNewConstMetric(c.cpu, prometheus.CounterValue, c.cpuStats.Nice, c.hostname, "nice")
+	ch <- prometheus.MustNewConstMetric(c.cpu, prometheus.CounterValue, c.cpuStats.System, c.hostname, "system")
+	ch <- prometheus.MustNewConstMetric(c.cpu, prometheus.CounterValue, c.cpuStats.Idle, c.hostname, "idle")
+	ch <- prometheus.MustNewConstMetric(c.cpu, prometheus.CounterValue, c.cpuStats.Iowait, c.hostname, "iowait")
+	ch <- prometheus.MustNewConstMetric(c.cpu, prometheus.CounterValue, c.cpuStats.IRQ, c.hostname, "irq")
+	ch <- prometheus.MustNewConstMetric(c.cpu, prometheus.CounterValue, c.cpuStats.SoftIRQ, c.hostname, "softirq")
+	ch <- prometheus.MustNewConstMetric(c.cpu, prometheus.CounterValue, c.cpuStats.Steal, c.hostname, "steal")
+	return nil
+}
+
+// updateCPUStats updates the internal cache of CPU stats.
+func (c *cpuCollector) updateCPUStats(newStats procfs.CPUStat) {
+
+	// Acquire a lock to update the stats.
+	c.cpuStatsMutex.Lock()
+	defer c.cpuStatsMutex.Unlock()
+
+	cpuStats := c.cpuStats
+
+	// If idle jumps backwards by more than X seconds, assume we had a hotplug event and reset the stats for this CPU.
+	if (cpuStats.Idle - newStats.Idle) >= jumpBackSeconds {
+		level.Debug(c.logger).Log("msg", jumpBackDebugMessage, "old_value", c.cpuStats.Idle, "new_value", newStats.Idle)
+		cpuStats = procfs.CPUStat{}
+	}
+
+	if newStats.Idle >= cpuStats.Idle {
+		cpuStats.Idle = newStats.Idle
+	} else {
+		level.Debug(c.logger).Log("msg", "CPU Idle counter jumped backwards", "old_value", c.cpuStats.Idle, "new_value", newStats.Idle)
+	}
+
+	if newStats.User >= cpuStats.User {
+		cpuStats.User = newStats.User
+	} else {
+		level.Debug(c.logger).Log("msg", "CPU User counter jumped backwards", "old_value", c.cpuStats.User, "new_value", newStats.User)
+	}
+
+	if newStats.Nice >= cpuStats.Nice {
+		cpuStats.Nice = newStats.Nice
+	} else {
+		level.Debug(c.logger).Log("msg", "CPU Nice counter jumped backwards", "old_value", c.cpuStats.Nice, "new_value", newStats.Nice)
+	}
+
+	if newStats.System >= cpuStats.System {
+		cpuStats.System = newStats.System
+	} else {
+		level.Debug(c.logger).Log("msg", "CPU System counter jumped backwards", "old_value", c.cpuStats.System, "new_value", newStats.System)
+	}
+
+	if newStats.Iowait >= cpuStats.Iowait {
+		cpuStats.Iowait = newStats.Iowait
+	} else {
+		level.Debug(c.logger).Log("msg", "CPU Iowait counter jumped backwards", "old_value", c.cpuStats.Iowait, "new_value", newStats.Iowait)
+	}
+
+	if newStats.IRQ >= cpuStats.IRQ {
+		cpuStats.IRQ = newStats.IRQ
+	} else {
+		level.Debug(c.logger).Log("msg", "CPU IRQ counter jumped backwards", "old_value", c.cpuStats.IRQ, "new_value", newStats.IRQ)
+	}
+
+	if newStats.SoftIRQ >= cpuStats.SoftIRQ {
+		cpuStats.SoftIRQ = newStats.SoftIRQ
+	} else {
+		level.Debug(c.logger).Log("msg", "CPU SoftIRQ counter jumped backwards", "old_value", c.cpuStats.SoftIRQ, "new_value", newStats.SoftIRQ)
+	}
+
+	if newStats.Steal >= cpuStats.Steal {
+		cpuStats.Steal = newStats.Steal
+	} else {
+		level.Debug(c.logger).Log("msg", "CPU Steal counter jumped backwards", "old_value", c.cpuStats.Steal, "new_value", newStats.Steal)
+	}
+
+	if newStats.Guest >= cpuStats.Guest {
+		cpuStats.Guest = newStats.Guest
+	} else {
+		level.Debug(c.logger).Log("msg", "CPU Guest counter jumped backwards", "old_value", c.cpuStats.Guest, "new_value", newStats.Guest)
+	}
+
+	if newStats.GuestNice >= cpuStats.GuestNice {
+		cpuStats.GuestNice = newStats.GuestNice
+	} else {
+		level.Debug(c.logger).Log("msg", "CPU GuestNice counter jumped backwards", "old_value", c.cpuStats.GuestNice, "new_value", newStats.GuestNice)
+	}
+
+	c.cpuStats = cpuStats
+}

--- a/pkg/collector/cpu_test.go
+++ b/pkg/collector/cpu_test.go
@@ -1,0 +1,91 @@
+//go:build !nocpu
+// +build !nocpu
+
+package collector
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/prometheus/procfs"
+)
+
+func makeTestCPUCollector(s procfs.CPUStat) *cpuCollector {
+	dupStat := s
+	return &cpuCollector{
+		logger:   log.NewNopLogger(),
+		cpuStats: dupStat,
+	}
+}
+
+func TestCPU(t *testing.T) {
+	firstCPUStat := procfs.CPUStat{
+		User:      100.0,
+		Nice:      100.0,
+		System:    100.0,
+		Idle:      100.0,
+		Iowait:    100.0,
+		IRQ:       100.0,
+		SoftIRQ:   100.0,
+		Steal:     100.0,
+		Guest:     100.0,
+		GuestNice: 100.0,
+	}
+
+	c := makeTestCPUCollector(firstCPUStat)
+	want := procfs.CPUStat{
+		User:      101.0,
+		Nice:      101.0,
+		System:    101.0,
+		Idle:      101.0,
+		Iowait:    101.0,
+		IRQ:       101.0,
+		SoftIRQ:   101.0,
+		Steal:     101.0,
+		Guest:     101.0,
+		GuestNice: 101.0}
+	c.updateCPUStats(want)
+	got := c.cpuStats
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("should have %v CPU Stat: got %v", want, got)
+	}
+
+	c = makeTestCPUCollector(firstCPUStat)
+	jumpBack := procfs.CPUStat{
+		User:      99.9,
+		Nice:      99.9,
+		System:    99.9,
+		Idle:      99.9,
+		Iowait:    99.9,
+		IRQ:       99.9,
+		SoftIRQ:   99.9,
+		Steal:     99.9,
+		Guest:     99.9,
+		GuestNice: 99.9,
+	}
+	c.updateCPUStats(jumpBack)
+	got = c.cpuStats
+	if reflect.DeepEqual(jumpBack, got) {
+		t.Fatalf("should have %v CPU Stat: got %v", firstCPUStat, got)
+	}
+
+	c = makeTestCPUCollector(firstCPUStat)
+	resetIdle := procfs.CPUStat{
+		User:      102.0,
+		Nice:      102.0,
+		System:    102.0,
+		Idle:      1.0,
+		Iowait:    102.0,
+		IRQ:       102.0,
+		SoftIRQ:   102.0,
+		Steal:     102.0,
+		Guest:     102.0,
+		GuestNice: 102.0,
+	}
+	c.updateCPUStats(resetIdle)
+	got = c.cpuStats
+	if !reflect.DeepEqual(resetIdle, got) {
+		t.Fatalf("should have %v CPU Stat: got %v", resetIdle, got)
+	}
+}

--- a/pkg/collector/fixtures/output/e2e-test-cgroupsv1-output.txt
+++ b/pkg/collector/fixtures/output/e2e-test-cgroupsv1-output.txt
@@ -1,3 +1,13 @@
+# HELP batchjob_cpu_seconds_total Seconds the CPUs spent in each mode.
+# TYPE batchjob_cpu_seconds_total counter
+batchjob_cpu_seconds_total{hostname="",mode="idle"} 89790.04
+batchjob_cpu_seconds_total{hostname="",mode="iowait"} 35.52
+batchjob_cpu_seconds_total{hostname="",mode="irq"} 0.02
+batchjob_cpu_seconds_total{hostname="",mode="nice"} 6.12
+batchjob_cpu_seconds_total{hostname="",mode="softirq"} 39.44
+batchjob_cpu_seconds_total{hostname="",mode="steal"} 0
+batchjob_cpu_seconds_total{hostname="",mode="system"} 1119.22
+batchjob_cpu_seconds_total{hostname="",mode="user"} 3018.54
 # HELP batchjob_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which batchjob_exporter was built, and the goos and goarch for the build.
 # TYPE batchjob_exporter_build_info gauge
 # HELP batchjob_ipmi_dcmi_current_watts_total Current Power consumption in watts
@@ -9,6 +19,15 @@ batchjob_ipmi_dcmi_max_watts_total{hostname=""} 504
 # HELP batchjob_ipmi_dcmi_min_watts_total Minimum Power consumption in watts
 # TYPE batchjob_ipmi_dcmi_min_watts_total counter
 batchjob_ipmi_dcmi_min_watts_total{hostname=""} 68
+# HELP batchjob_meminfo_MemAvailable_bytes Memory information field MemAvailable_bytes.
+# TYPE batchjob_meminfo_MemAvailable_bytes gauge
+batchjob_meminfo_MemAvailable_bytes{hostname=""} 0
+# HELP batchjob_meminfo_MemFree_bytes Memory information field MemFree_bytes.
+# TYPE batchjob_meminfo_MemFree_bytes gauge
+batchjob_meminfo_MemFree_bytes{hostname=""} 4.50891776e+08
+# HELP batchjob_meminfo_MemTotal_bytes Memory information field MemTotal_bytes.
+# TYPE batchjob_meminfo_MemTotal_bytes gauge
+batchjob_meminfo_MemTotal_bytes{hostname=""} 1.6042172416e+10
 # HELP batchjob_rapl_package_joules_total Current RAPL package value in joules
 # TYPE batchjob_rapl_package_joules_total counter
 batchjob_rapl_package_joules_total{hostname="",index="0",path="pkg/collector/fixtures/sys/class/powercap/intel-rapl:0"} 258218.293244
@@ -17,7 +36,9 @@ batchjob_rapl_package_joules_total{hostname="",index="1",path="pkg/collector/fix
 # TYPE batchjob_scrape_collector_duration_seconds gauge
 # HELP batchjob_scrape_collector_success batchjob_exporter: Whether a collector succeeded.
 # TYPE batchjob_scrape_collector_success gauge
+batchjob_scrape_collector_success{collector="cpu"} 1
 batchjob_scrape_collector_success{collector="ipmi_dcmi"} 1
+batchjob_scrape_collector_success{collector="meminfo"} 1
 batchjob_scrape_collector_success{collector="rapl"} 1
 batchjob_scrape_collector_success{collector="slurm"} 1
 # HELP batchjob_slurm_job_cpu_system_seconds Total job CPU system seconds
@@ -48,12 +69,6 @@ batchjob_slurm_job_memory_total_bytes{batch="slurm",hostname="",jobaccount="test
 # HELP batchjob_slurm_job_memory_used_bytes Memory used in bytes
 # TYPE batchjob_slurm_job_memory_used_bytes gauge
 batchjob_slurm_job_memory_used_bytes{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 4.0194048e+07
-# HELP batchjob_system_memory_total_bytes Available total system memory in bytes
-# TYPE batchjob_system_memory_total_bytes gauge
-batchjob_system_memory_total_bytes{batch="slurm",hostname=""} 1.6042172416e+10
-# HELP batchjob_system_proc_cpu_total_seconds Total processes CPU time in seconds
-# TYPE batchjob_system_proc_cpu_total_seconds gauge
-batchjob_system_proc_cpu_total_seconds{batch="slurm",hostname=""} 4137.76
 # HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
 # TYPE go_gc_duration_seconds summary
 # HELP go_goroutines Number of goroutines that currently exist.

--- a/pkg/collector/fixtures/output/e2e-test-cgroupsv2-all-metrics-output.txt
+++ b/pkg/collector/fixtures/output/e2e-test-cgroupsv2-all-metrics-output.txt
@@ -1,3 +1,13 @@
+# HELP batchjob_cpu_seconds_total Seconds the CPUs spent in each mode.
+# TYPE batchjob_cpu_seconds_total counter
+batchjob_cpu_seconds_total{hostname="",mode="idle"} 89790.04
+batchjob_cpu_seconds_total{hostname="",mode="iowait"} 35.52
+batchjob_cpu_seconds_total{hostname="",mode="irq"} 0.02
+batchjob_cpu_seconds_total{hostname="",mode="nice"} 6.12
+batchjob_cpu_seconds_total{hostname="",mode="softirq"} 39.44
+batchjob_cpu_seconds_total{hostname="",mode="steal"} 0
+batchjob_cpu_seconds_total{hostname="",mode="system"} 1119.22
+batchjob_cpu_seconds_total{hostname="",mode="user"} 3018.54
 # HELP batchjob_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which batchjob_exporter was built, and the goos and goarch for the build.
 # TYPE batchjob_exporter_build_info gauge
 # HELP batchjob_ipmi_dcmi_current_watts_total Current Power consumption in watts
@@ -9,6 +19,15 @@ batchjob_ipmi_dcmi_max_watts_total{hostname=""} 504
 # HELP batchjob_ipmi_dcmi_min_watts_total Minimum Power consumption in watts
 # TYPE batchjob_ipmi_dcmi_min_watts_total counter
 batchjob_ipmi_dcmi_min_watts_total{hostname=""} 68
+# HELP batchjob_meminfo_MemAvailable_bytes Memory information field MemAvailable_bytes.
+# TYPE batchjob_meminfo_MemAvailable_bytes gauge
+batchjob_meminfo_MemAvailable_bytes{hostname=""} 0
+# HELP batchjob_meminfo_MemFree_bytes Memory information field MemFree_bytes.
+# TYPE batchjob_meminfo_MemFree_bytes gauge
+batchjob_meminfo_MemFree_bytes{hostname=""} 4.50891776e+08
+# HELP batchjob_meminfo_MemTotal_bytes Memory information field MemTotal_bytes.
+# TYPE batchjob_meminfo_MemTotal_bytes gauge
+batchjob_meminfo_MemTotal_bytes{hostname=""} 1.6042172416e+10
 # HELP batchjob_rapl_package_joules_total Current RAPL package value in joules
 # TYPE batchjob_rapl_package_joules_total counter
 batchjob_rapl_package_joules_total{hostname="",index="0",path="pkg/collector/fixtures/sys/class/powercap/intel-rapl:0"} 258218.293244
@@ -17,7 +36,9 @@ batchjob_rapl_package_joules_total{hostname="",index="1",path="pkg/collector/fix
 # TYPE batchjob_scrape_collector_duration_seconds gauge
 # HELP batchjob_scrape_collector_success batchjob_exporter: Whether a collector succeeded.
 # TYPE batchjob_scrape_collector_success gauge
+batchjob_scrape_collector_success{collector="cpu"} 1
 batchjob_scrape_collector_success{collector="ipmi_dcmi"} 1
+batchjob_scrape_collector_success{collector="meminfo"} 1
 batchjob_scrape_collector_success{collector="rapl"} 1
 batchjob_scrape_collector_success{collector="slurm"} 1
 # HELP batchjob_slurm_job_cpu_psi_seconds Total CPU PSI in seconds
@@ -63,12 +84,6 @@ batchjob_slurm_job_memsw_total_bytes{batch="slurm",hostname="",jobaccount="testa
 # HELP batchjob_slurm_job_memsw_used_bytes Swap used in bytes
 # TYPE batchjob_slurm_job_memsw_used_bytes gauge
 batchjob_slurm_job_memsw_used_bytes{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 0
-# HELP batchjob_system_memory_total_bytes Available total system memory in bytes
-# TYPE batchjob_system_memory_total_bytes gauge
-batchjob_system_memory_total_bytes{batch="slurm",hostname=""} 1.6042172416e+10
-# HELP batchjob_system_proc_cpu_total_seconds Total processes CPU time in seconds
-# TYPE batchjob_system_proc_cpu_total_seconds gauge
-batchjob_system_proc_cpu_total_seconds{batch="slurm",hostname=""} 4137.76
 # HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
 # TYPE go_gc_duration_seconds summary
 # HELP go_goroutines Number of goroutines that currently exist.

--- a/pkg/collector/fixtures/output/e2e-test-cgroupsv2-amd-output.txt
+++ b/pkg/collector/fixtures/output/e2e-test-cgroupsv2-amd-output.txt
@@ -1,3 +1,13 @@
+# HELP batchjob_cpu_seconds_total Seconds the CPUs spent in each mode.
+# TYPE batchjob_cpu_seconds_total counter
+batchjob_cpu_seconds_total{hostname="",mode="idle"} 89790.04
+batchjob_cpu_seconds_total{hostname="",mode="iowait"} 35.52
+batchjob_cpu_seconds_total{hostname="",mode="irq"} 0.02
+batchjob_cpu_seconds_total{hostname="",mode="nice"} 6.12
+batchjob_cpu_seconds_total{hostname="",mode="softirq"} 39.44
+batchjob_cpu_seconds_total{hostname="",mode="steal"} 0
+batchjob_cpu_seconds_total{hostname="",mode="system"} 1119.22
+batchjob_cpu_seconds_total{hostname="",mode="user"} 3018.54
 # HELP batchjob_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which batchjob_exporter was built, and the goos and goarch for the build.
 # TYPE batchjob_exporter_build_info gauge
 # HELP batchjob_ipmi_dcmi_current_watts_total Current Power consumption in watts
@@ -9,6 +19,15 @@ batchjob_ipmi_dcmi_max_watts_total{hostname=""} 504
 # HELP batchjob_ipmi_dcmi_min_watts_total Minimum Power consumption in watts
 # TYPE batchjob_ipmi_dcmi_min_watts_total counter
 batchjob_ipmi_dcmi_min_watts_total{hostname=""} 68
+# HELP batchjob_meminfo_MemAvailable_bytes Memory information field MemAvailable_bytes.
+# TYPE batchjob_meminfo_MemAvailable_bytes gauge
+batchjob_meminfo_MemAvailable_bytes{hostname=""} 0
+# HELP batchjob_meminfo_MemFree_bytes Memory information field MemFree_bytes.
+# TYPE batchjob_meminfo_MemFree_bytes gauge
+batchjob_meminfo_MemFree_bytes{hostname=""} 4.50891776e+08
+# HELP batchjob_meminfo_MemTotal_bytes Memory information field MemTotal_bytes.
+# TYPE batchjob_meminfo_MemTotal_bytes gauge
+batchjob_meminfo_MemTotal_bytes{hostname=""} 1.6042172416e+10
 # HELP batchjob_rapl_package_joules_total Current RAPL package value in joules
 # TYPE batchjob_rapl_package_joules_total counter
 batchjob_rapl_package_joules_total{hostname="",index="0",path="pkg/collector/fixtures/sys/class/powercap/intel-rapl:0"} 258218.293244
@@ -17,7 +36,9 @@ batchjob_rapl_package_joules_total{hostname="",index="1",path="pkg/collector/fix
 # TYPE batchjob_scrape_collector_duration_seconds gauge
 # HELP batchjob_scrape_collector_success batchjob_exporter: Whether a collector succeeded.
 # TYPE batchjob_scrape_collector_success gauge
+batchjob_scrape_collector_success{collector="cpu"} 1
 batchjob_scrape_collector_success{collector="ipmi_dcmi"} 1
+batchjob_scrape_collector_success{collector="meminfo"} 1
 batchjob_scrape_collector_success{collector="rapl"} 1
 batchjob_scrape_collector_success{collector="slurm"} 1
 # HELP batchjob_slurm_job_cpu_system_seconds Total job CPU system seconds
@@ -48,12 +69,6 @@ batchjob_slurm_job_memory_total_bytes{batch="slurm",hostname="",jobaccount="test
 # HELP batchjob_slurm_job_memory_used_bytes Memory used in bytes
 # TYPE batchjob_slurm_job_memory_used_bytes gauge
 batchjob_slurm_job_memory_used_bytes{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 4.111491072e+09
-# HELP batchjob_system_memory_total_bytes Available total system memory in bytes
-# TYPE batchjob_system_memory_total_bytes gauge
-batchjob_system_memory_total_bytes{batch="slurm",hostname=""} 1.6042172416e+10
-# HELP batchjob_system_proc_cpu_total_seconds Total processes CPU time in seconds
-# TYPE batchjob_system_proc_cpu_total_seconds gauge
-batchjob_system_proc_cpu_total_seconds{batch="slurm",hostname=""} 4137.76
 # HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
 # TYPE go_gc_duration_seconds summary
 # HELP go_goroutines Number of goroutines that currently exist.

--- a/pkg/collector/fixtures/output/e2e-test-cgroupsv2-nogpu-output.txt
+++ b/pkg/collector/fixtures/output/e2e-test-cgroupsv2-nogpu-output.txt
@@ -1,3 +1,13 @@
+# HELP batchjob_cpu_seconds_total Seconds the CPUs spent in each mode.
+# TYPE batchjob_cpu_seconds_total counter
+batchjob_cpu_seconds_total{hostname="",mode="idle"} 89790.04
+batchjob_cpu_seconds_total{hostname="",mode="iowait"} 35.52
+batchjob_cpu_seconds_total{hostname="",mode="irq"} 0.02
+batchjob_cpu_seconds_total{hostname="",mode="nice"} 6.12
+batchjob_cpu_seconds_total{hostname="",mode="softirq"} 39.44
+batchjob_cpu_seconds_total{hostname="",mode="steal"} 0
+batchjob_cpu_seconds_total{hostname="",mode="system"} 1119.22
+batchjob_cpu_seconds_total{hostname="",mode="user"} 3018.54
 # HELP batchjob_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which batchjob_exporter was built, and the goos and goarch for the build.
 # TYPE batchjob_exporter_build_info gauge
 # HELP batchjob_ipmi_dcmi_current_watts_total Current Power consumption in watts
@@ -9,6 +19,15 @@ batchjob_ipmi_dcmi_max_watts_total{hostname=""} 504
 # HELP batchjob_ipmi_dcmi_min_watts_total Minimum Power consumption in watts
 # TYPE batchjob_ipmi_dcmi_min_watts_total counter
 batchjob_ipmi_dcmi_min_watts_total{hostname=""} 68
+# HELP batchjob_meminfo_MemAvailable_bytes Memory information field MemAvailable_bytes.
+# TYPE batchjob_meminfo_MemAvailable_bytes gauge
+batchjob_meminfo_MemAvailable_bytes{hostname=""} 0
+# HELP batchjob_meminfo_MemFree_bytes Memory information field MemFree_bytes.
+# TYPE batchjob_meminfo_MemFree_bytes gauge
+batchjob_meminfo_MemFree_bytes{hostname=""} 4.50891776e+08
+# HELP batchjob_meminfo_MemTotal_bytes Memory information field MemTotal_bytes.
+# TYPE batchjob_meminfo_MemTotal_bytes gauge
+batchjob_meminfo_MemTotal_bytes{hostname=""} 1.6042172416e+10
 # HELP batchjob_rapl_package_joules_total Current RAPL package value in joules
 # TYPE batchjob_rapl_package_joules_total counter
 batchjob_rapl_package_joules_total{hostname="",index="0",path="pkg/collector/fixtures/sys/class/powercap/intel-rapl:0"} 258218.293244
@@ -17,7 +36,9 @@ batchjob_rapl_package_joules_total{hostname="",index="1",path="pkg/collector/fix
 # TYPE batchjob_scrape_collector_duration_seconds gauge
 # HELP batchjob_scrape_collector_success batchjob_exporter: Whether a collector succeeded.
 # TYPE batchjob_scrape_collector_success gauge
+batchjob_scrape_collector_success{collector="cpu"} 1
 batchjob_scrape_collector_success{collector="ipmi_dcmi"} 1
+batchjob_scrape_collector_success{collector="meminfo"} 1
 batchjob_scrape_collector_success{collector="rapl"} 1
 batchjob_scrape_collector_success{collector="slurm"} 1
 # HELP batchjob_slurm_job_cpu_system_seconds Total job CPU system seconds
@@ -44,12 +65,6 @@ batchjob_slurm_job_memory_total_bytes{batch="slurm",hostname="",jobaccount="test
 # HELP batchjob_slurm_job_memory_used_bytes Memory used in bytes
 # TYPE batchjob_slurm_job_memory_used_bytes gauge
 batchjob_slurm_job_memory_used_bytes{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 4.111491072e+09
-# HELP batchjob_system_memory_total_bytes Available total system memory in bytes
-# TYPE batchjob_system_memory_total_bytes gauge
-batchjob_system_memory_total_bytes{batch="slurm",hostname=""} 1.6042172416e+10
-# HELP batchjob_system_proc_cpu_total_seconds Total processes CPU time in seconds
-# TYPE batchjob_system_proc_cpu_total_seconds gauge
-batchjob_system_proc_cpu_total_seconds{batch="slurm",hostname=""} 4137.76
 # HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
 # TYPE go_gc_duration_seconds summary
 # HELP go_goroutines Number of goroutines that currently exist.

--- a/pkg/collector/fixtures/output/e2e-test-cgroupsv2-nvidia-output.txt
+++ b/pkg/collector/fixtures/output/e2e-test-cgroupsv2-nvidia-output.txt
@@ -1,3 +1,13 @@
+# HELP batchjob_cpu_seconds_total Seconds the CPUs spent in each mode.
+# TYPE batchjob_cpu_seconds_total counter
+batchjob_cpu_seconds_total{hostname="",mode="idle"} 89790.04
+batchjob_cpu_seconds_total{hostname="",mode="iowait"} 35.52
+batchjob_cpu_seconds_total{hostname="",mode="irq"} 0.02
+batchjob_cpu_seconds_total{hostname="",mode="nice"} 6.12
+batchjob_cpu_seconds_total{hostname="",mode="softirq"} 39.44
+batchjob_cpu_seconds_total{hostname="",mode="steal"} 0
+batchjob_cpu_seconds_total{hostname="",mode="system"} 1119.22
+batchjob_cpu_seconds_total{hostname="",mode="user"} 3018.54
 # HELP batchjob_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which batchjob_exporter was built, and the goos and goarch for the build.
 # TYPE batchjob_exporter_build_info gauge
 # HELP batchjob_ipmi_dcmi_current_watts_total Current Power consumption in watts
@@ -9,6 +19,15 @@ batchjob_ipmi_dcmi_max_watts_total{hostname=""} 504
 # HELP batchjob_ipmi_dcmi_min_watts_total Minimum Power consumption in watts
 # TYPE batchjob_ipmi_dcmi_min_watts_total counter
 batchjob_ipmi_dcmi_min_watts_total{hostname=""} 68
+# HELP batchjob_meminfo_MemAvailable_bytes Memory information field MemAvailable_bytes.
+# TYPE batchjob_meminfo_MemAvailable_bytes gauge
+batchjob_meminfo_MemAvailable_bytes{hostname=""} 0
+# HELP batchjob_meminfo_MemFree_bytes Memory information field MemFree_bytes.
+# TYPE batchjob_meminfo_MemFree_bytes gauge
+batchjob_meminfo_MemFree_bytes{hostname=""} 4.50891776e+08
+# HELP batchjob_meminfo_MemTotal_bytes Memory information field MemTotal_bytes.
+# TYPE batchjob_meminfo_MemTotal_bytes gauge
+batchjob_meminfo_MemTotal_bytes{hostname=""} 1.6042172416e+10
 # HELP batchjob_rapl_package_joules_total Current RAPL package value in joules
 # TYPE batchjob_rapl_package_joules_total counter
 batchjob_rapl_package_joules_total{hostname="",index="0",path="pkg/collector/fixtures/sys/class/powercap/intel-rapl:0"} 258218.293244
@@ -17,7 +36,9 @@ batchjob_rapl_package_joules_total{hostname="",index="1",path="pkg/collector/fix
 # TYPE batchjob_scrape_collector_duration_seconds gauge
 # HELP batchjob_scrape_collector_success batchjob_exporter: Whether a collector succeeded.
 # TYPE batchjob_scrape_collector_success gauge
+batchjob_scrape_collector_success{collector="cpu"} 1
 batchjob_scrape_collector_success{collector="ipmi_dcmi"} 1
+batchjob_scrape_collector_success{collector="meminfo"} 1
 batchjob_scrape_collector_success{collector="rapl"} 1
 batchjob_scrape_collector_success{collector="slurm"} 1
 # HELP batchjob_slurm_job_cpu_system_seconds Total job CPU system seconds
@@ -48,12 +69,6 @@ batchjob_slurm_job_memory_total_bytes{batch="slurm",hostname="",jobaccount="test
 # HELP batchjob_slurm_job_memory_used_bytes Memory used in bytes
 # TYPE batchjob_slurm_job_memory_used_bytes gauge
 batchjob_slurm_job_memory_used_bytes{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 4.111491072e+09
-# HELP batchjob_system_memory_total_bytes Available total system memory in bytes
-# TYPE batchjob_system_memory_total_bytes gauge
-batchjob_system_memory_total_bytes{batch="slurm",hostname=""} 1.6042172416e+10
-# HELP batchjob_system_proc_cpu_total_seconds Total processes CPU time in seconds
-# TYPE batchjob_system_proc_cpu_total_seconds gauge
-batchjob_system_proc_cpu_total_seconds{batch="slurm",hostname=""} 4137.76
 # HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
 # TYPE go_gc_duration_seconds summary
 # HELP go_goroutines Number of goroutines that currently exist.

--- a/pkg/collector/fixtures/output/e2e-test-cgroupsv2-procfs-output.txt
+++ b/pkg/collector/fixtures/output/e2e-test-cgroupsv2-procfs-output.txt
@@ -1,3 +1,13 @@
+# HELP batchjob_cpu_seconds_total Seconds the CPUs spent in each mode.
+# TYPE batchjob_cpu_seconds_total counter
+batchjob_cpu_seconds_total{hostname="",mode="idle"} 89790.04
+batchjob_cpu_seconds_total{hostname="",mode="iowait"} 35.52
+batchjob_cpu_seconds_total{hostname="",mode="irq"} 0.02
+batchjob_cpu_seconds_total{hostname="",mode="nice"} 6.12
+batchjob_cpu_seconds_total{hostname="",mode="softirq"} 39.44
+batchjob_cpu_seconds_total{hostname="",mode="steal"} 0
+batchjob_cpu_seconds_total{hostname="",mode="system"} 1119.22
+batchjob_cpu_seconds_total{hostname="",mode="user"} 3018.54
 # HELP batchjob_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, goversion from which batchjob_exporter was built, and the goos and goarch for the build.
 # TYPE batchjob_exporter_build_info gauge
 # HELP batchjob_ipmi_dcmi_current_watts_total Current Power consumption in watts
@@ -9,6 +19,15 @@ batchjob_ipmi_dcmi_max_watts_total{hostname=""} 504
 # HELP batchjob_ipmi_dcmi_min_watts_total Minimum Power consumption in watts
 # TYPE batchjob_ipmi_dcmi_min_watts_total counter
 batchjob_ipmi_dcmi_min_watts_total{hostname=""} 68
+# HELP batchjob_meminfo_MemAvailable_bytes Memory information field MemAvailable_bytes.
+# TYPE batchjob_meminfo_MemAvailable_bytes gauge
+batchjob_meminfo_MemAvailable_bytes{hostname=""} 0
+# HELP batchjob_meminfo_MemFree_bytes Memory information field MemFree_bytes.
+# TYPE batchjob_meminfo_MemFree_bytes gauge
+batchjob_meminfo_MemFree_bytes{hostname=""} 4.50891776e+08
+# HELP batchjob_meminfo_MemTotal_bytes Memory information field MemTotal_bytes.
+# TYPE batchjob_meminfo_MemTotal_bytes gauge
+batchjob_meminfo_MemTotal_bytes{hostname=""} 1.6042172416e+10
 # HELP batchjob_rapl_package_joules_total Current RAPL package value in joules
 # TYPE batchjob_rapl_package_joules_total counter
 batchjob_rapl_package_joules_total{hostname="",index="0",path="pkg/collector/fixtures/sys/class/powercap/intel-rapl:0"} 258218.293244
@@ -17,7 +36,9 @@ batchjob_rapl_package_joules_total{hostname="",index="1",path="pkg/collector/fix
 # TYPE batchjob_scrape_collector_duration_seconds gauge
 # HELP batchjob_scrape_collector_success batchjob_exporter: Whether a collector succeeded.
 # TYPE batchjob_scrape_collector_success gauge
+batchjob_scrape_collector_success{collector="cpu"} 1
 batchjob_scrape_collector_success{collector="ipmi_dcmi"} 1
+batchjob_scrape_collector_success{collector="meminfo"} 1
 batchjob_scrape_collector_success{collector="rapl"} 1
 batchjob_scrape_collector_success{collector="slurm"} 1
 # HELP batchjob_slurm_job_cpu_system_seconds Total job CPU system seconds
@@ -48,12 +69,6 @@ batchjob_slurm_job_memory_total_bytes{batch="slurm",hostname="",jobaccount="test
 # HELP batchjob_slurm_job_memory_used_bytes Memory used in bytes
 # TYPE batchjob_slurm_job_memory_used_bytes gauge
 batchjob_slurm_job_memory_used_bytes{batch="slurm",hostname="",jobaccount="testacc",jobid="1009248",jobuser="testusr",jobuuid="0f0ac288-dbd4-a9a3-df3a-ab14ef9d51d5",step="",task=""} 4.111491072e+09
-# HELP batchjob_system_memory_total_bytes Available total system memory in bytes
-# TYPE batchjob_system_memory_total_bytes gauge
-batchjob_system_memory_total_bytes{batch="slurm",hostname=""} 1.6042172416e+10
-# HELP batchjob_system_proc_cpu_total_seconds Total processes CPU time in seconds
-# TYPE batchjob_system_proc_cpu_total_seconds gauge
-batchjob_system_proc_cpu_total_seconds{batch="slurm",hostname=""} 4137.76
 # HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
 # TYPE go_gc_duration_seconds summary
 # HELP go_goroutines Number of goroutines that currently exist.

--- a/pkg/collector/helper.go
+++ b/pkg/collector/helper.go
@@ -1,9 +1,7 @@
 package collector
 
 import (
-	"bufio"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -236,51 +234,4 @@ func GetAMDGPUDevices(rocmSmiPath string, logger log.Logger) (map[int]Device, er
 	}
 	// Get all devices
 	return parseAmdSmioutput(string(rocmSmiOutput), logger), nil
-}
-
-// Get memory info of the host
-// Nicked from node_exporter: https://github.com/prometheus/node_exporter/blob/master/collector/meminfo_linux.go
-func GetMemInfo() (map[string]float64, error) {
-	file, err := os.Open(procFilePath("meminfo"))
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	return parseMemInfo(file)
-}
-
-// Parse memory info file at /proc/meminfo
-func parseMemInfo(r io.Reader) (map[string]float64, error) {
-	var (
-		memInfo = map[string]float64{}
-		scanner = bufio.NewScanner(r)
-	)
-
-	for scanner.Scan() {
-		line := scanner.Text()
-		parts := strings.Fields(line)
-		// Workaround for empty lines occasionally occur in CentOS 6.2 kernel 3.10.90.
-		if len(parts) == 0 {
-			continue
-		}
-		fv, err := strconv.ParseFloat(parts[1], 64)
-		if err != nil {
-			return nil, fmt.Errorf("invalid value in meminfo: %w", err)
-		}
-		key := parts[0][:len(parts[0])-1] // remove trailing : from key
-		// Active(anon) -> Active_anon
-		key = reParens.ReplaceAllString(key, "_${1}")
-		switch len(parts) {
-		case 2: // no unit
-		case 3: // has unit, we presume kB
-			fv *= 1024
-			key = key + "_bytes"
-		default:
-			return nil, fmt.Errorf("invalid line in meminfo: %s", line)
-		}
-		memInfo[key] = fv
-	}
-
-	return memInfo, scanner.Err()
 }

--- a/pkg/collector/helper_test.go
+++ b/pkg/collector/helper_test.go
@@ -3,7 +3,6 @@
 package collector
 
 import (
-	"os"
 	"reflect"
 	"testing"
 )
@@ -92,26 +91,5 @@ func TestParseAmdSmiOutput(t *testing.T) {
 
 	if !reflect.DeepEqual(gpuDevices, getExpectedAmdDevs()) {
 		t.Errorf("Expected: %v, Got: %v", getExpectedAmdDevs(), gpuDevices)
-	}
-}
-
-func TestMemInfo(t *testing.T) {
-	file, err := os.Open("fixtures/proc/meminfo")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer file.Close()
-
-	memInfo, err := parseMemInfo(file)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if want, got := 16042172416.0, memInfo["MemTotal_bytes"]; want != got {
-		t.Errorf("want memory total %f, got %f", want, got)
-	}
-
-	if want, got := 16424894464.0, memInfo["DirectMap2M_bytes"]; want != got {
-		t.Errorf("want memory directMap2M %f, got %f", want, got)
 	}
 }

--- a/pkg/collector/meminfo.go
+++ b/pkg/collector/meminfo.go
@@ -1,0 +1,128 @@
+//go:build !nomeminfo
+// +build !nomeminfo
+
+package collector
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	memInfoSubsystem = "meminfo"
+)
+
+type meminfoCollector struct {
+	logger   log.Logger
+	hostname string
+}
+
+var meminfoAllStatistics = BatchJobExporterApp.Flag(
+	"collector.meminfo.all.stats",
+	"Enable collecting all meminfo stats (default is disabled).",
+).Default("false").Bool()
+
+func init() {
+	RegisterCollector(memInfoSubsystem, defaultEnabled, NewMeminfoCollector)
+}
+
+// NewMeminfoCollector returns a new Collector exposing memory stats.
+func NewMeminfoCollector(logger log.Logger) (Collector, error) {
+	return &meminfoCollector{
+		logger:   logger,
+		hostname: hostname,
+	}, nil
+}
+
+// Update calls (*meminfoCollector).getMemInfo to get the platform specific
+// memory metrics.
+func (c *meminfoCollector) Update(ch chan<- prometheus.Metric) error {
+	var metricType prometheus.ValueType
+	memInfo, err := c.getMemInfo()
+	if err != nil {
+		return fmt.Errorf("couldn't get meminfo: %w", err)
+	}
+	level.Debug(c.logger).Log("msg", "Set node_mem", "memInfo", fmt.Sprintf("%v", memInfo))
+
+	// Export only MemTotal, MemFree and MemAvailable fields if meminfoAllStatistics is false
+	var memInfoStats map[string]float64
+	if *meminfoAllStatistics {
+		memInfoStats = memInfo
+	} else {
+		memInfoStats = map[string]float64{
+			"MemTotal_bytes":     memInfo["MemTotal_bytes"],
+			"MemFree_bytes":      memInfo["MemFree_bytes"],
+			"MemAvailable_bytes": memInfo["MemAvailable_bytes"],
+		}
+	}
+	for k, v := range memInfoStats {
+		if strings.HasSuffix(k, "_total") {
+			metricType = prometheus.CounterValue
+		} else {
+			metricType = prometheus.GaugeValue
+		}
+		ch <- prometheus.MustNewConstMetric(
+			prometheus.NewDesc(
+				prometheus.BuildFQName(Namespace, memInfoSubsystem, k),
+				fmt.Sprintf("Memory information field %s.", k),
+				[]string{"hostname"}, nil,
+			),
+			metricType, v, c.hostname,
+		)
+	}
+	return nil
+}
+
+// Get memory info from /proc/meminfo
+func (c *meminfoCollector) getMemInfo() (map[string]float64, error) {
+	file, err := os.Open(procFilePath("meminfo"))
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	return parseMemInfo(file)
+}
+
+// Parse /proc/meminfo file and get memory info
+func parseMemInfo(r io.Reader) (map[string]float64, error) {
+	var (
+		memInfo = map[string]float64{}
+		scanner = bufio.NewScanner(r)
+	)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.Fields(line)
+		// Workaround for empty lines occasionally occur in CentOS 6.2 kernel 3.10.90.
+		if len(parts) == 0 {
+			continue
+		}
+		fv, err := strconv.ParseFloat(parts[1], 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value in meminfo: %w", err)
+		}
+		key := parts[0][:len(parts[0])-1] // remove trailing : from key
+		// Active(anon) -> Active_anon
+		key = reParens.ReplaceAllString(key, "_${1}")
+		switch len(parts) {
+		case 2: // no unit
+		case 3: // has unit, we presume kB
+			fv *= 1024
+			key = key + "_bytes"
+		default:
+			return nil, fmt.Errorf("invalid line in meminfo: %s", line)
+		}
+		memInfo[key] = fv
+	}
+
+	return memInfo, scanner.Err()
+}

--- a/pkg/collector/meminfo_test.go
+++ b/pkg/collector/meminfo_test.go
@@ -1,0 +1,30 @@
+//go:build !nomemory
+// +build !nomemory
+
+package collector
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMemInfo(t *testing.T) {
+	file, err := os.Open("fixtures/proc/meminfo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	memInfo, err := parseMemInfo(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want, got := 16042172416.0, memInfo["MemTotal_bytes"]; want != got {
+		t.Errorf("want memory total %f, got %f", want, got)
+	}
+
+	if want, got := 16424894464.0, memInfo["DirectMap2M_bytes"]; want != got {
+		t.Errorf("want memory directMap2M %f, got %f", want, got)
+	}
+}

--- a/pkg/collector/slurm_test.go
+++ b/pkg/collector/slurm_test.go
@@ -38,7 +38,7 @@ func TestCgroupsV2SlurmJobMetrics(t *testing.T) {
 		cgroups:          "v2",
 		gpuDevs:          mockGPUDevices(),
 		cgroupsRootPath:  *cgroupfsPath,
-		memTotal:         float64(123456),
+		hostMemTotal:     float64(123456),
 		slurmCgroupsPath: fmt.Sprintf("%s/system.slice/slurmstepd.scope", *cgroupfsPath),
 		logger:           log.NewNopLogger(),
 	}
@@ -92,7 +92,7 @@ func TestCgroupsV2SlurmJobMetricsWithProcFs(t *testing.T) {
 		cgroups:          "v2",
 		cgroupsRootPath:  *cgroupfsPath,
 		gpuDevs:          mockGPUDevices(),
-		memTotal:         float64(123456),
+		hostMemTotal:     float64(123456),
 		slurmCgroupsPath: fmt.Sprintf("%s/system.slice/slurmstepd.scope", *cgroupfsPath),
 		logger:           log.NewNopLogger(),
 	}

--- a/scripts/checkmetrics.sh
+++ b/scripts/checkmetrics.sh
@@ -9,7 +9,7 @@ fi
 search_dir="$2"
 for entry in "$search_dir"/*
 do
-  lint=$($1 check metrics < "$entry" 2>&1 | grep -v -E "^batchjob_slurm_job_(memory_fail_count|memsw_fail_count)")
+  lint=$($1 check metrics < "$entry" 2>&1 | grep -v -E "^batchjob_slurm_job_(memory_fail_count|memsw_fail_count)|batchjob_meminfo_")
 
   if [[ -n $lint ]]; then
       echo -e "Some Prometheus metrics do not follow best practices:\n"


### PR DESCRIPTION
- Use `cpu` and `meminfo` collectors from `node_exporter` to get system level metrics
- Add GH workflows for testing and building packages
- General maintenance